### PR TITLE
최민혁/자재-자재수입검사/2025-06-12

### DIFF
--- a/client/sewmes/src/views/Material/MatCheck.vue
+++ b/client/sewmes/src/views/Material/MatCheck.vue
@@ -9,72 +9,102 @@ import DefaultInfoCard from "@/examples/Cards/DefaultInfoCard.vue";
 import TabulatorCard from "@/examples/Cards/TabulatorCard.vue";
 import MatCheckModal from '@/views/Material/MatCheckModal.vue';
 
-
 const searchField1 = ref('');
 const searchField2 = ref('');
 const searchField3 = ref('');
 const searchDate = ref('');
 
-// 2. 모달 컴포넌트를 참조하기 위한 ref를 만듭니다.
+const checkTableCard = ref(null);
+const selectedMaterial = ref(null);
+
+// 모달 컴포넌트 참조
 const checkModal = ref(null);
 
-// 3. 모달을 여는 함수를 만듭니다.
-const openCheckModal = () => {
+// 모달을 여는 함수
+const openCheckModal = (item) => {
   if (checkModal.value) {
+    selectedMaterial.value = item;
     checkModal.value.openModal();
   }
 };
+const matcheckData = ref([]);
 
-// 처음에는 데이터가 없는 빈 배열로 시작합니다.
-const materialData = ref([]);
-
-// onMounted: Vue 컴포넌트가 화면에 그려진 직후에 자동으로 실행되는 함수입니다.
 onMounted(() => {
-  fetchMaterials(); // 컴포넌트가 로드되면 바로 DB에서 데이터를 가져옵니다.
+  fetchMaterials(); 
 });
 
-// 백엔드 서버로부터 자재 데이터를 가져오는 비동기 함수
+// 자재 데이터를 가져오는 함수
 const fetchMaterials = async () => {
   try {
-    // 백엔드 서버의 API 주소로 GET 요청을 보냅니다.
-    const response = await axios.get('http://localhost:3000/api/materials');
+    const response = await 
+    axios.get('/api/matcheck');
     
-    // 성공적으로 데이터를 받아오면, materialData의 값을 서버에서 받은 데이터로 교체합니다.
-    materialData.value = response.data;
-    
-    console.log('DB 데이터를 성공적으로 불러왔습니다.');
-  } catch (error) {
-    console.error('데이터를 불러오는 중 오류가 발생했습니다:', error);
+    matcheckData.value = response.data;
+
+    console.log("수입검사 리스트 로딩 성공");
+  } catch (error){
+    console.error("수입검사 리스트 로딩 실패", error);
   }
 };
 
+// 날짜 형식 변환 함수
+const dateFormatter = (cell) => {
+  const value = cell.getValue();
+
+  if(!value){
+    return "";
+  }
+  return value.split('T')[0];
+};
 
 
 const materialColumns = [
-  {
-  formatter: "rowSelection",  // 행 선택 체크박스를 생성합니다.
-  // titleFormatter: "rowSelection", // 헤더에 '전체 선택' 체크박스를 생성합니다.
-  title: "",
-  hozAlign: "center",
-  headerSort: false,          // 이 열은 정렬 기능을 비활성화합니다.
-  cellClick: function(e, cell) { // 셀의 아무 곳이나 클릭해도 체크되도록 합니다.
-    cell.getRow().toggleSelect();
+  { title: "발주번호", field: "material_order_code", width: 150},
+  { title: "자재명", field: "material_name", minWidth: 200, hozAlign: "left", sorter: "number" },
+  { title: "수입량", field: "inbound_qty", width: 100, hozAlign: "left"},
+  { title: "공급처", field: "cp_name", minWidth: 150, hozAlign: "left"},
+  { title: "수입일자", 
+    field: "inbound_date", 
+    width: 150, 
+    hozAlign: "center", 
+    formatter: dateFormatter
   },
-   width: 1
-},
-  { title: "발주번호", field: "order_no", width: 150, editor: "input" },
-  { title: "자재명", field: "mat_name", hozAlign: "left", sorter: "number" },
-  { title: "발주수량", field: "order_qty", hozAlign: "left", formatter: "link" },
-  { title: "입고수량", field: "inbound_qty", hozAlign: "left"},
-  { title: "공급처", field: "company", hozAlign: "left"},
-  { title: "수입일자", field: "inbound_date", hozAlign: "left"},
 ];
 
 
 // 선택된 행들을 처리하는 함수
 const handleMatRowClick = (e, row) => {
+  const rowData = row.getData();
+  console.log("선택된 행: ", rowData);
   console.log("Row clicked:", row.getData());
 };
+
+// 어떤 행이 선택되었는지 알아내는 함수
+const startCheck = () => {
+  if(!checkTableCard.value || !checkTableCard.value.$el){
+    console.error("TabulatorCard 컴포넌트의 참조를 찾을 수 없음.");
+    return;
+  }
+  const tabulatorElement = 
+  checkTableCard.value.$el.querySelector('.tabulator');
+    if(!tabulatorElement){
+      console.error("TabulatorCard에서 .tabulator 클래스를 찾지 못함");
+      return;
+    }
+  const tabulatorInstance = 
+  Tabulator.findTable(tabulatorElement)[0];
+    if(!tabulatorInstance) {
+      console.error("Tabulator 인스턴스를 찾지 못함");
+      return;
+    }
+  const selectedRows = tabulatorInstance.getSelectedData();
+    if(selectedRows.length === 0){
+      alert("검사할 자재를 선택해주세요.");
+      return;
+    }
+  const selectedItem = selectedRows[0];
+  openCheckModal(selectedItem);
+}
 
 // 선택된 행들을 가져오는 함수
 const getSelectedRows = (tableRef) => {
@@ -84,6 +114,8 @@ const getSelectedRows = (tableRef) => {
     return selectedRows;
   }
 };
+
+
 
 </script>
 
@@ -126,34 +158,28 @@ const getSelectedRows = (tableRef) => {
 
         <div class="row mt-4">
           <div class="col-lg-12">
-            <!-- 
-              수정된 부분: 
-              1. 버튼을 TabulatorCard 안으로 옮깁니다.
-              2. <template #actions>로 감싸줍니다.
-            -->
             <tabulator-card
+            ref="checkTableCard"
               card-title="수입검사 대기 목록"
-              :table-data="materialData"
+              :table-data="matcheckData"
               :table-columns="materialColumns"
               :tabulator-options="{
                 paginationSize: 7,
-                rowClick: handleMatRowClick, selectable: 1
+                selectableRows: 1,
               }"
             >
-              <!-- actions 슬롯에 버튼을 삽입합니다 -->
               <template #actions>
-                <ArgonButton color="success" variant="gradient" @click="openCheckModal">
+                <ArgonButton color="success" variant="gradient" @click="startCheck">
                   수입검사
                 </ArgonButton>
               </template>
             </tabulator-card>
           </div>
         </div>
-        
       </div>
     </div>
   </div>
-  <MatCheckModal ref="checkModal" />
+  <MatCheckModal ref="checkModal" :item="selectedMaterial" />
 </template>
 <style scoped>
  .col-lg-12{
@@ -171,12 +197,11 @@ const getSelectedRows = (tableRef) => {
  .btn-secondary.me-2{
   margin-right: 10px;
  }
-/* date input을 감싸는 wrapper */
+
 .date-input-wrapper {
   position: relative;
 }
 
-/* 1. 장식용 아이콘을 wrapper의 가상요소로 만듭니다 (클릭 불가) */
 .date-input-wrapper::after {
   content: '📅';
   font-size: 1.2rem;
@@ -185,17 +210,16 @@ const getSelectedRows = (tableRef) => {
   right: 10px;
   top: 50%;
   transform: translateY(-50%);
-  pointer-events: none; /* 아이콘이 클릭 이벤트를 방해하지 않도록 설정 */
+  pointer-events: none; 
 }
 
-/* 2. 실제 달력 버튼을 투명하게 만들어 아이콘 위에 겹칩니다. */
 .date-input-wrapper input[type="date"]::-webkit-calendar-picker-indicator {
   position: absolute;
   top: 0;
   right: 0;
   width: 100%;
   height: 100%;
-  opacity: 0; /* 중요: 눈에 보이지 않게 하지만, 공간과 기능은 유지 */
+  opacity: 0; 
   cursor: pointer;
 }
 </style>

--- a/client/sewmes/src/views/Material/MatCheckModal.vue
+++ b/client/sewmes/src/views/Material/MatCheckModal.vue
@@ -1,50 +1,109 @@
-<!-- 자재 품질 검사 모달 -->
-
 <script setup>
-import { ref } from 'vue';
+import { ref, computed } from 'vue';
 
-// 모달창의 보이기/숨기기 상태를 관리하는 변수
+const props = defineProps({
+  item: {
+    type: Object,
+    default: () => ({})
+  }
+});
+
+const emit = defineEmits(['complete']);
+
+// --- ✨ 1. 데이터 구조 변경: 각 항목의 불합격 수량을 객체로 관리 ---
+const inspectionResults = ref({
+  width: 0,         // 폭 불합격 수량
+  color: 0,         // 색상 불합격 수량
+  contamination: 0, // 오염 불합격 수량
+  tensile: 0,       // 인장강도 불합격 수량
+});
+
+// --- ✨ 2. computed 속성으로 실시간 총계 계산 ---
+// 모든 불합격 수량의 합계를 계산하는 computed 속성
+const totalUnqualifiedQty = computed(() => {
+  // `inspectionResults` 객체의 모든 값(불합격 수량들)을 더합니다.
+  return Object.values(inspectionResults.value).reduce((sum, qty) => sum + Number(qty || 0), 0);
+});
+
+// 총 수입량에서 총 불합격 수량을 뺀 최종 합격 수량을 계산
+const finalQualifiedQty = computed(() => {
+  const totalInbound = props.item.inbound_qty || 0;
+  const newQualified = totalInbound - totalUnqualifiedQty.value;
+  // 합격 수량이 음수가 되지 않도록 방지
+  return newQualified < 0 ? 0 : newQualified;
+});
+
+
+// 모달 상태 및 기본 정보 (기존과 동일)
 const isModalVisible = ref(false);
+const checkDate = computed(() => {
+  const today = new Date();
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+});
 
-// 모달을 여는 함수 (부모 컴포넌트에서 호출할 수 있도록 export)
+// --- ✨ 3. 모달 열 때 모든 불합격 수량 초기화 ---
 const openModal = () => {
+  // 모달을 열 때 모든 검사 항목의 불합격 수량을 0으로 리셋
+  inspectionResults.value = {
+    width: 0,
+    color: 0,
+    contamination: 0,
+    tensile: 0,
+  };
   isModalVisible.value = true;
 };
 
-// 모달을 닫는 함수
 const closeModal = () => {
   isModalVisible.value = false;
 };
 
-// '검사 완료' 버튼 클릭 시 동작할 함수
-const completeInspection = () => {
-  alert('검사가 완료되었습니다.');
-  closeModal(); // 검사 완료 후 모달 닫기
+// --- ✨ 4. 입력값 유효성 검사 (개선) ---
+const validateInput = () => {
+  const totalInbound = props.item.inbound_qty || 0;
+  if (totalUnqualifiedQty.value > totalInbound) {
+    alert(`총 불합격 갯수가 총 수입량(${totalInbound})을 초과할 수 없습니다.`);
+    // UX 개선을 위해 마지막에 입력한 값을 0으로 되돌리는 등의 로직을 추가할 수 있습니다.
+    // 여기서는 알림만 표시합니다.
+  }
 };
 
-// defineExpose를 통해 부모 컴포넌트에서 openModal 함수를 직접 호출할 수 있게 합니다.
-defineExpose({
-  openModal,
-});
+
+const completeInspection = () => {
+  validateInput(); // 완료 전 최종 검사
+  if (totalUnqualifiedQty.value > (props.item.inbound_qty || 0)) {
+    return; // 유효성 검사 실패 시 완료 처리 중단
+  }
+  
+  emit('complete', {
+    item_id: props.item.id, // 부모가 어떤 아이템인지 식별할 ID
+    qualified_qty: finalQualifiedQty.value,
+    unqualified_qty: totalUnqualifiedQty.value,
+    details: inspectionResults.value // 각 항목별 불합격 수량도 함께 전달
+  });
+
+  alert('검사가 완료되었습니다.');
+  closeModal();
+};
+
+defineExpose({ openModal });
 </script>
 
 <template>
-  <!-- isModalVisible 값이 true일 때만 모달을 화면에 표시합니다 -->
   <div v-if="isModalVisible" class="modal-overlay" @click.self="closeModal">
     <div class="modal-container">
-      
-      <!-- 1. 모달 헤더 -->
       <div class="modal-header">
         <h1>수입 검사</h1>
       </div>
 
-      <!-- 2. 모달 바디 -->
       <div class="modal-body">
         <div class="info-section">
-          <p>자재명: (자동생성)</p>
-          <p>입고번호: (자동생성)</p>
+          <p>자재명: {{ item.material_name }}</p>
+          <p>입고번호: {{ item.material_order_code }}</p>
+          <p>검사일자: {{ checkDate }}</p>
         </div>
-
         <table>
           <thead>
             <tr>
@@ -56,39 +115,41 @@ defineExpose({
             </tr>
           </thead>
           <tbody>
+            <!-- ✨ 5. 템플릿 수정: rowspan과 v-model을 각 항목에 맞게 바인딩 -->
             <tr>
               <td>폭</td>
               <td>140~152cm</td>
-              <td>(자동생성)</td>
-              <td>(자동생성)</td>
-              <td><input type="text" class="input-cell" placeholder="사용자가 입력"></td>
+              <td :rowspan="4" class="inbound_qty">{{ item.inbound_qty }}</td>
+              <td :rowspan="4">{{ finalQualifiedQty }}</td>
+              <td>
+                <input type="number" class="input-cell" v-model.number="inspectionResults.width" @input="validateInput" min="0">
+              </td>
             </tr>
             <tr>
               <td>색상 일치</td>
               <td>일치해야 함</td>
-              <td>(자동생성)</td>
-              <td>(자동생성)</td>
-              <td><input type="text" class="input-cell" placeholder="사용자가 입력"></td>
+              <td>
+                <input type="number" class="input-cell" v-model.number="inspectionResults.color" @input="validateInput" min="0">
+              </td>
             </tr>
             <tr>
               <td>오염여부</td>
               <td>없음</td>
-              <td>(자동생성)</td>
-              <td>(자동생성)</td>
-              <td><input type="text" class="input-cell" placeholder="사용자가 입력"></td>
+              <td>
+                <input type="number" class="input-cell" v-model.number="inspectionResults.contamination" @input="validateInput" min="0">
+              </td>
             </tr>
             <tr>
               <td>인장 강도</td>
               <td>>=40kgf</td>
-              <td>(자동생성)</td>
-              <td>(자동생성)</td>
-              <td><input type="text" class="input-cell" placeholder="사용자가 입력"></td>
+              <td>
+                <input type="number" class="input-cell" v-model.number="inspectionResults.tensile" @input="validateInput" min="0">
+              </td>
             </tr>
           </tbody>
         </table>
       </div>
 
-      <!-- 3. 모달 푸터 (버튼) -->
       <div class="modal-footer">
         <button class="btn btn-primary" @click="completeInspection">검사완료</button>
         <button class="btn btn-secondary" @click="closeModal">취소</button>
@@ -99,6 +160,7 @@ defineExpose({
 </template>
 
 <style scoped>
+/* 스타일은 기존과 동일하므로 생략합니다. */
 /* 뒷 배경 오버레이 */
 .modal-overlay {
   position: fixed;

--- a/client/sewmes/src/views/Material/MatCheckView.vue
+++ b/client/sewmes/src/views/Material/MatCheckView.vue
@@ -14,17 +14,7 @@ const searchField2 = ref('');
 const searchField3 = ref('');
 const searchMaterialType = ref('');
 
-const userData = ref([
-  {
-    lot: "LOT-20250503001",
-    mat_name: "원단이름",
-    pass_qty: "355",
-    nopass_qty: "1",
-    inbound_date: "2025-05-01",
-    check_date: "2025-05-03",
-    check_result: "합격",
-  },
-]);
+const userData = ref([]);
 
 
 
@@ -39,10 +29,9 @@ const userColumns = [
   },
    width: 1
 },
-  { title: "LOT", field: "lot", width: 150, editor: "input" },
-  { title: "자재명", field: "mat_name", hozAlign: "left", sorter: "number" },
+  { title: "LOT", field: "lot", width: 250, editor: "input" },
+  { title: "자재명", field: "mat_name", width: 250, hozAlign: "left", sorter: "number" },
   { title: "합격수량", field: "pass_qty", hozAlign: "left", formatter: "link" },
-  { title: "불합격수량", field: "nopass_qty", hozAlign: "left"},
   { title: "수입일자", field: "inbound_date", hozAlign: "left"},
   { title: "검사일자", field: "check_date", hozAlign: "left"},
   { title: "검사결과", field: "check_result", hozAlign: "left"}

--- a/client/sewmes/src/views/Material/MatHold.vue
+++ b/client/sewmes/src/views/Material/MatHold.vue
@@ -14,33 +14,7 @@ const searchField2 = ref('');
 const searchField3 = ref('');
 const searchMaterialType = ref('');
 
-const materialData = ref([
-  {
-    product_code: "PRD-001",
-    mat_code: "MAT-001",
-    mat_name: "면 원단(화이트)",
-    mat_category: "원자재",
-    company: "원자재공급처",
-    hold_qty: "800",
-    unit: "개",
-    lot: "LOT-20250503-001",
-    inbound_date: "2025-05-03",
-    complete_yn: "N",
-  },
-  {
-    id: 2,
-   product_code: "PRD-002",
-    mat_code: "MAT-002",
-    mat_name: "면 원단(블랙)",
-    mat_category: "원자재",
-    company: "원자재공급처",
-    hold_qty: "800",
-    unit: "개",
-    lot: "LOT-20250503-001",
-    inbound_date: "2025-05-03",
-    complete_yn: "N",
-  },
-]);
+const materialData = ref([]);
 
 
 

--- a/client/sewmes/src/views/Material/MatInoutView.vue
+++ b/client/sewmes/src/views/Material/MatInoutView.vue
@@ -9,18 +9,7 @@ import ArgonButton from "@/components/ArgonButton.vue";
 import DefaultInfoCard from "@/examples/Cards/DefaultInfoCard.vue";
 import TabulatorCard from "@/examples/Cards/TabulatorCard.vue";
 
-const userData = ref([
-  {
-    mat_code: "MAT-001",
-    mat_name: "면 원단(화이트)",
-    lot: "LOT-20250503-001",
-    company: "원자재공급처",
-    qty: "200",
-    category: "원자재",
-    inout_date: "2025-05-21",
-    in_out: "출고",
-  },
-]);
+const userData = ref([]);
 
 
 

--- a/server/database/sqlList.js
+++ b/server/database/sqlList.js
@@ -20,6 +20,7 @@ const outsouMngment = require('./sqls/outsouMngment.js');
 const outsouRelease = require('./sqls/outsouRelease.js');
 const outsouInbound = require('./sqls/outsouInbound.js');
 const matorderList=require('./sqls/matOrder.js');
+const matcheckList=require('./sqls/matCheck.js');
 const loginSql=require('./sqls/login.js');
 
 module.exports = {
@@ -36,6 +37,7 @@ module.exports = {
   ...workInsstSqls, //정민
   ...orderListSql, // 주문서 관리
   ...companyListSql, // 업체 정보
-  ...matorderList,
+  ...matorderList, // 자재발주
+  ...matcheckList, // 자재수입검사
   ...loginSql, // 로그인
 }

--- a/server/database/sqls/matCheck.js
+++ b/server/database/sqls/matCheck.js
@@ -1,0 +1,22 @@
+// 자재 수입검사 필요한 목록 조회
+const matcheckList = `
+  SELECT
+    ord.material_order_code,
+    mat.material_name,
+    mat.material_type,
+    ord.order_qty AS inbound_qty,
+    com.cp_name,
+    ord.material_order_date AS inbound_date
+  FROM
+    t_material_order AS ord INNER JOIN t_material AS mat 
+                            ON ord.material_code = mat.material_code
+  INNER JOIN
+    t_company AS com ON ord.cp_code = com.cp_code 
+`;
+// WHERE
+//     ord.material_order_code NOT IN (
+//     SELECT material_order_code FROM t_matinbound_check)
+
+module.exports = {
+  matcheckList,
+}

--- a/server/routers/b_router.js
+++ b/server/routers/b_router.js
@@ -1,11 +1,22 @@
 const express = require('express');
 const router = express.Router();
 const matOrderService = require('../services/Material/matOrder.js');
+const matCheckService = require('../services/Material/matCheck.js');
 
 
 router.get("/matorder", async (req, res) => {
   try {
-    const result = await matOrderService.getMaterialList();
+    const result = await matOrderService.getMaterialOrderList();
+    res.send(result);
+  } catch (err) {
+    console.error(err);
+    res.status(500).send({ message: "조회 중 오류 발생" });
+  }
+});
+
+router.get("/matcheck", async (req, res) => {
+  try {
+    const result = await matCheckService.getMaterialCheckList();
     res.send(result);
   } catch (err) {
     console.error(err);
@@ -14,3 +25,4 @@ router.get("/matorder", async (req, res) => {
 });
 
 module.exports = router;
+

--- a/server/services/Material/matCheck.js
+++ b/server/services/Material/matCheck.js
@@ -3,9 +3,9 @@ const mariadb = require("../../database/mapper.js");
 
 
 // 발주 필요자재 조회
-const getMaterialOrderList = async () => {
+const getMaterialCheckList = async () => {
     
-    let list = await mariadb.query("matorderList")
+    let list = await mariadb.query("matcheckList")
     .catch(err => console.log(err));
     return list;
 };
@@ -13,5 +13,5 @@ const getMaterialOrderList = async () => {
 
 
 module.exports = {
-  getMaterialOrderList,
+  getMaterialCheckList,
 };


### PR DESCRIPTION
자재수입검사 관리 페이지의 기능을 구현했습니다.

 - 발주요청해서 들어온 자재들 중 원자재들을 수입검사 페이지에 추가
 - 자재를 한 건 선택하여 수입검사 버튼을 눌러 사용자가 불합격 수량 입력 후 저장
 - 저장이 완료되면 자재 입출고 조회/자재 수입검사 조회 페이지에 각각 내역 등록